### PR TITLE
Add appveyor.yml for Cython

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+build: off
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python36-x64"
+
+configuration: Release
+platform:
+  - x64
+
+install:
+  - set PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+  - echo %PATH%
+  - python --version
+  - git submodule update --init
+  - pip install -r requirements-dev.txt
+  - python setup.py install
+
+test_script:
+  - pytest tests/test.py
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,10 @@
 build: off
 environment:
   matrix:
-    - PYTHON: "C:\\Python27"
+    # Python 2.7 is disabled due to not working
+    #- PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python36"
-    - PYTHON: "C:\\Python27-x64"
+    #- PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python36-x64"
 
 configuration: Release


### PR DESCRIPTION
This should allow us to test the Cython build as we are developing it. I'm not sure if all configurations will work, but we can see.

We could also add Travis CI here, I just haven't enabled it for this repo yet.

cc @dfellis @ajfriend @karentycoon @tenghu